### PR TITLE
Use ng-repeat since no longer a directive

### DIFF
--- a/scripts/controllers/hoursController.js
+++ b/scripts/controllers/hoursController.js
@@ -4,6 +4,7 @@ angular.module('upl-site').
     controller('HoursController', ['$scope', 'HoursFactory', 'CoordFactory', function($scope, Hours, Coords) {
         $scope.coords = [];
         $scope.hours = null;
+        $scope.times = ["8:50AM", "9:55AM", "11:00AM", "12:05PM", "1:20PM", "2:25PM", "3:30PM", "4:35PM", "5:40PM"];
 
         Coords.list().then(function(data) {
             $scope.coords = data;

--- a/views/hours.html
+++ b/views/hours.html
@@ -10,78 +10,16 @@
                 <th>Thursday</th>
                 <th>Friday</th>
             </tr>
-            <tr>
-                <td>8:50AM</td>
-                <td>{{hours.Monday["8:50AM"]}}</td>
-                <td>{{hours.Tuesday["8:50AM"]}}</td>
-                <td>{{hours.Wednesday["8:50AM"]}}</td>
-                <td>{{hours.Thursday["8:50AM"]}}</td>
-                <td>{{hours.Friday["8:50AM"]}}</td>
+
+            <tr ng-repeat="time in times">
+                <td>{{time}}</td>
+                <td>{{hours.Monday[time]}}</td>
+                <td>{{hours.Tuesday[time]}}</td>
+                <td>{{hours.Wednesday[time]}}</td>
+                <td>{{hours.Thursday[time]}}</td>
+                <td>{{hours.Friday[time]}}</td>
             </tr>
-            <tr>
-                <td>9:55AM</td>
-                <td>{{hours.Monday["9:55AM"]}}</td>
-                <td>{{hours.Tuesday["9:55AM"]}}</td>
-                <td>{{hours.Wednesday["9:55AM"]}}</td>
-                <td>{{hours.Thursday["9:55AM"]}}</td>
-                <td>{{hours.Friday["9:55AM"]}}</td>
-            </tr>
-            <tr>
-                <td>11:00AM</td>
-                <td>{{hours.Monday["11:00AM"]}}</td>
-                <td>{{hours.Tuesday["11:00AM"]}}</td>
-                <td>{{hours.Wednesday["11:00AM"]}}</td>
-                <td>{{hours.Thursday["11:00AM"]}}</td>
-                <td>{{hours.Friday["11:00AM"]}}</td>
-            </tr>
-            <tr>
-                <td>12:05PM</td>
-                <td>{{hours.Monday["12:05PM"]}}</td>
-                <td>{{hours.Tuesday["12:05PM"]}}</td>
-                <td>{{hours.Wednesday["12:05PM"]}}</td>
-                <td>{{hours.Thursday["12:05PM"]}}</td>
-                <td>{{hours.Friday["12:05PM"]}}</td>
-            </tr>
-            <tr>
-                <td>1:20PM</td>
-                <td>{{hours.Monday["1:20PM"]}}</td>
-                <td>{{hours.Tuesday["1:20PM"]}}</td>
-                <td>{{hours.Wednesday["1:20PM"]}}</td>
-                <td>{{hours.Thursday["1:20PM"]}}</td>
-                <td>{{hours.Friday["1:20PM"]}}</td>
-            </tr>
-            <tr>
-                <td>2:25PM</td>
-                <td>{{hours.Monday["2:25PM"]}}</td>
-                <td>{{hours.Tuesday["2:25PM"]}}</td>
-                <td>{{hours.Wednesday["2:25PM"]}}</td>
-                <td>{{hours.Thursday["2:25PM"]}}</td>
-                <td>{{hours.Friday["2:25PM"]}}</td>
-            </tr>
-            <tr>
-                <td>3:30PM</td>
-                <td>{{hours.Monday["3:30PM"]}}</td>
-                <td>{{hours.Tuesday["3:30PM"]}}</td>
-                <td>{{hours.Wednesday["3:30PM"]}}</td>
-                <td>{{hours.Thursday["3:30PM"]}}</td>
-                <td>{{hours.Friday["3:30PM"]}}</td>
-            </tr>
-            <tr>
-                <td>4:35PM</td>
-                <td>{{hours.Monday["4:35PM"]}}</td>
-                <td>{{hours.Tuesday["4:35PM"]}}</td>
-                <td>{{hours.Wednesday["4:35PM"]}}</td>
-                <td>{{hours.Thursday["4:35PM"]}}</td>
-                <td>{{hours.Friday["4:35PM"]}}</td>
-            </tr>
-            <tr>
-                <td>5:40PM</td>
-                <td>{{hours.Monday["5:40PM"]}}</td>
-                <td>{{hours.Tuesday["5:40PM"]}}</td>
-                <td>{{hours.Wednesday["5:40PM"]}}</td>
-                <td>{{hours.Thursday["5:40PM"]}}</td>
-                <td>{{hours.Friday["5:40PM"]}}</td>
-            </tr>
+            
         </tbody>
     </table>
 
@@ -91,202 +29,46 @@
                 <th class="st-key">Time</th>
                 <th class="st-val">Monday</th>
             </tr>
-            <tr>
-                <td class="st-key">8:50AM</td>
-                <td class="st-val">{{hours.Monday["8:50AM"]}}</td>
+            <tr ng-repeat="time in times">
+                <td class="st-key">{{time}}</td>
+                <td class="st-val">{{hours.Monday[time]}}</td>
             </tr>
-            <tr>
-                <td class="st-key">9:55AM</td>
-                <td class="st-val">{{hours.Monday["9:55AM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">11:00AM</td>
-                <td class="st-val">{{hours.Monday["11:00AM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">12:05PM</td>
-                <td class="st-val">{{hours.Monday["12:05PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">1:20PM</td>
-                <td class="st-val">{{hours.Monday["1:20PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">2:25PM</td>
-                <td class="st-val">{{hours.Monday["2:25PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">3:30PM</td>
-                <td class="st-val">{{hours.Monday["3:30PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">4:35PM</td>
-                <td class="st-val">{{hours.Monday["4:35PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">5:40PM</td>
-                <td class="st-val">{{hours.Monday["5:40PM"]}}</td>
-            </tr>
+
             <tr class="st-head-row st-head-row-main">
                 <th class="st-key">Time</th>
                 <th class="st-val">Tuesday</th>
             </tr>
-            <tr>
-                <td class="st-key">8:50AM</td>
-                <td class="st-val">{{hours.Tuesday["8:50AM"]}}</td>
+            <tr ng-repeat="time in times">
+                <td class="st-key">{{time}}</td>
+                <td class="st-val">{{hours.Tuesday[time]}}</td>
             </tr>
-            <tr>
-                <td class="st-key">9:55AM</td>
-                <td class="st-val">{{hours.Tuesday["9:55AM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">11:00AM</td>
-                <td class="st-val">{{hours.Tuesday["11:00AM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">12:05PM</td>
-                <td class="st-val">{{hours.Tuesday["12:05PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">1:20PM</td>
-                <td class="st-val">{{hours.Tuesday["1:20PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">2:25PM</td>
-                <td class="st-val">{{hours.Tuesday["2:25PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">3:30PM</td>
-                <td class="st-val">{{hours.Tuesday["3:30PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">4:35PM</td>
-                <td class="st-val">{{hours.Tuesday["4:35PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">5:40PM</td>
-                <td class="st-val">{{hours.Tuesday["5:40PM"]}}</td>
-            </tr>
+
             <tr class="st-head-row st-head-row-main">
                 <th class="st-key">Time</th>
                 <th class="st-val">Wednesday</th>
             </tr>
-            <tr>
-                <td class="st-key">8:50AM</td>
-                <td class="st-val">{{hours.Wednesday["8:50AM"]}}</td>
+            <tr ng-repeat="time in times">
+                <td class="st-key">{{time}}</td>
+                <td class="st-val">{{hours.Wednesday[time]}}</td>
             </tr>
-            <tr>
-                <td class="st-key">9:55AM</td>
-                <td class="st-val">{{hours.Wednesday["9:55AM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">11:00AM</td>
-                <td class="st-val">{{hours.Wednesday["11:00AM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">12:05PM</td>
-                <td class="st-val">{{hours.Wednesday["12:05PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">1:20PM</td>
-                <td class="st-val">{{hours.Wednesday["1:20PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">2:25PM</td>
-                <td class="st-val">{{hours.Wednesday["2:25PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">3:30PM</td>
-                <td class="st-val">{{hours.Wednesday["3:30PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">4:35PM</td>
-                <td class="st-val">{{hours.Wednesday["4:35PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">5:40PM</td>
-                <td class="st-val">{{hours.Wednesday["5:40PM"]}}</td>
-            </tr>
+
             <tr class="st-head-row st-head-row-main">
                 <th class="st-key">Time</th>
                 <th class="st-val">Thursday</th>
             </tr>
-            <tr>
-                <td class="st-key">8:50AM</td>
-                <td class="st-val">{{hours.Thursday["8:50AM"]}}</td>
+            <tr ng-repeat="time in times">
+                <td class="st-key">{{time}}</td>
+                <td class="st-val">{{hours.Thursday[time]}}</td>
             </tr>
-            <tr>
-                <td class="st-key">9:55AM</td>
-                <td class="st-val">{{hours.Thursday["9:55AM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">11:00AM</td>
-                <td class="st-val">{{hours.Thursday["11:00AM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">12:05PM</td>
-                <td class="st-val">{{hours.Thursday["12:05PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">1:20PM</td>
-                <td class="st-val">{{hours.Thursday["1:20PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">2:25PM</td>
-                <td class="st-val">{{hours.Thursday["2:25PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">3:30PM</td>
-                <td class="st-val">{{hours.Thursday["3:30PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">4:35PM</td>
-                <td class="st-val">{{hours.Thursday["4:35PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">5:40PM</td>
-                <td class="st-val">{{hours.Thursday["5:40PM"]}}</td>
-            </tr>
+
             <tr class="st-head-row st-head-row-main">
                 <th class="st-key">Time</th>
                 <th class="st-val">Friday</th>
             </tr>
-            <tr>
-                <td class="st-key">8:50AM</td>
-                <td class="st-val">{{hours.Friday["8:50AM"]}}</td>
+            <tr ng-repeat="time in times">
+                <td class="st-key">{{time}}</td>
+                <td class="st-val">{{hours.Friday[time]}}</td>
             </tr>
-            <tr>
-                <td class="st-key">9:55AM</td>
-                <td class="st-val">{{hours.Friday["9:55AM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">11:00AM</td>
-                <td class="st-val">{{hours.Friday["11:00AM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">12:05PM</td>
-                <td class="st-val">{{hours.Friday["12:05PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">1:20PM</td>
-                <td class="st-val">{{hours.Friday["1:20PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">2:25PM</td>
-                <td class="st-val">{{hours.Friday["2:25PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">3:30PM</td>
-                <td class="st-val">{{hours.Friday["3:30PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">4:35PM</td>
-                <td class="st-val">{{hours.Friday["4:35PM"]}}</td>
-            </tr>
-            <tr>
-                <td class="st-key">5:40PM</td>
-                <td class="st-val">{{hours.Friday["5:40PM"]}}</td>
-            </tr>        
         </tbody>
     </table>
 </div>


### PR DESCRIPTION
Since you ditched the directive, maybe it's a good idea to bring the ng-repeats back.

Also, I couldn't get nested ng-repeats to work right for some reason. Normally, you can ng-init something on an outer repeat to be able to access it on an inner repeat, but that absolutely would not work and I have no idea why.