### PR TITLE
Don't change .para-expand css on click

### DIFF
--- a/scripts/directives/showHide.js
+++ b/scripts/directives/showHide.js
@@ -14,15 +14,12 @@ angular.module('upl-site').
                     }
                     
                     var para = angular.element(element[0].querySelector(".para-hidden"));
-                    var expand = angular.element(element[0].querySelector(".para-expand"));
                     if (para.css("display") === "none") {
                         para.css("display", "block");
-                        expand.css("display", "none");
                     } else {
                         para.css("display", "none");
-                        expand.css("display", "inline");
                     }
                 });                
             }
-        }
-    })
+        };
+    });


### PR DESCRIPTION
I've disabled all changes to the .para-expand css on click events. This is one way of fixing #77. I also added some semicolons because my editor complained about those being absent :ok_hand: :100: :ok_hand: 