### PR TITLE
GitHub sort

### DIFF
--- a/scripts/controllers/homeController.js
+++ b/scripts/controllers/homeController.js
@@ -5,17 +5,55 @@ angular.module('upl-site').
         $scope.events = [];
         $scope.projects = [];
 
+        /* Events */
         Events.list().then(function(data) {
             $scope.events = data.Upcoming.slice(0, 3);
         }, function(data) {
             alert(data);
         });
 
+        /* Projects */
         Projects.list().then(function(data) {
+
+            var successHandler = function(project) {
+              return function(latestCommitTimestamp) {
+                console.log(`title: ${ project.title }, ts: ${ latestCommitTimestamp }`);
+                project.latestCommitTimestamp = latestCommitTimestamp;
+              };
+            };
+
+            var failureHandler = function(project) {
+              return function() {
+                console.log('fetch failure');
+                project.latestCommitTimestamp = 0;
+              };
+            };
+
+            // first get all the GitHub data
+            for (var projectInd in data) {
+              var project = data[projectInd];
+              var ghPromise = Projects.getGitHubDataPromise(project.link);
+
+              if (ghPromise) {
+                /*
+                ghPromise.then(function(latestCommitTimestamp) {
+                  console.log(`title: ${ project.title }, ts: ${ latestCommitTimestamp }`);
+                  project.latestCommitTimestamp = latestCommitTimestamp;
+                });
+                */
+                ghPromise.then(successHandler(project), failureHandler(project));
+              } else {
+                project.latestCommitTimestamp = 0;
+              }
+            }
+
+            // TODO: this should be done in the view
             data.sort(function(a, b) {
+                // TODO: github sort here (but in view!!!)
                 return a.title.toLocaleLowerCase()
                     .localeCompare(b.title.toLocaleLowerCase());
             });
+            // TODO: the Left/Right split should be accomplished through CSS
             var left = true;
             var row = 0;
             for (var i = 0; i < data.length; i++) {
@@ -23,6 +61,7 @@ angular.module('upl-site').
                 if (d.description.length > 100) {
                     d.description = d.description.substring(0, 100) + "...";
                 }
+                // TODO: shouldn't `left` be `i % 2 == 0` and `row` be `Math.floor(i/2)`?
                 if (left) {
                     $scope.projects.push([d]);
                     left = false;
@@ -36,6 +75,7 @@ angular.module('upl-site').
             alert(data);
         });
 
+        /* Webcam stuff */
         var moveCamera = function(id, val, highVal) {
             Lab.setCameraPosition(val);
         };

--- a/scripts/controllers/homeController.js
+++ b/scripts/controllers/homeController.js
@@ -1,7 +1,8 @@
 "use strict";
 
 angular.module('upl-site').
-    controller('HomeController', ['$scope', 'EventsFactory', 'ProjectsFactory', "LabFactory", function($scope, Events, Projects, Lab) {
+    controller('HomeController', ['$scope', 'EventsFactory', 'ProjectsFactory', "LabFactory", '$filter',
+      function($scope, Events, Projects, Lab, $filter) {
         $scope.events = [];
         $scope.projects = [];
 
@@ -48,11 +49,15 @@ angular.module('upl-site').
             }
 
             // TODO: this should be done in the view
+            /*
             data.sort(function(a, b) {
                 // TODO: github sort here (but in view!!!)
                 return a.title.toLocaleLowerCase()
                     .localeCompare(b.title.toLocaleLowerCase());
             });
+            -- transitioning this sort into the view
+            */
+            data = $filter('orderBy')(data, ['-latestCommitTimestamp', '+title']);
             // TODO: the Left/Right split should be accomplished through CSS
             var left = true;
             var row = 0;

--- a/scripts/services/projectsFactory.js
+++ b/scripts/services/projectsFactory.js
@@ -85,12 +85,14 @@ angular.module('upl-site').
 
         var failureGitHubResponseHandler = function (repoLink) {
           return function (response) {
-            // TODO: test this failure case!
-            // TODO: this will happen if the rate limit is hit!
-            // XXX: maybe don't fetch the latest commit if the field is already valid...
-            // rate limit <-> reponse.status === 403
-            console.log('FAILURE!', response);
-            ghRepos[repoLink].reject('Error loading GitHub information');
+            // this will likely happen if the rate limit is hit!
+            // rate limit exceeded <-> reponse.status === 403;
+            // if you are worried about the 403 errors logged in the console,
+            // they are put there by the browser (i.e. there is no method to
+            // catch or hide them);
+            // since we are using this failure handler and rejecting the
+            // promise, we can handle this case gracefully later on
+            ghRepos[repoLink].reject(response);
           };
         };
 

--- a/scripts/services/projectsFactory.js
+++ b/scripts/services/projectsFactory.js
@@ -22,12 +22,14 @@ angular.module('upl-site').
             $http.get('content/projects/projects.json').then(function(response) {
                 deferred.resolve(response.data);
                 // XXX: maybe zip in the latest commit date with the project objects?
+                console.log('POPULATING...'); // only repopulates on refresh (duh)
                 populateGitHubData(response.data);
             }, function(response) {
                 deferred.reject("Error loading projects");
             });
         };
 
+        // TODO: only fetch if the field isn't present
         var populateGitHubData = function(data) {
           // first build up the map of link => promise
           data.forEach(function(project) {
@@ -88,6 +90,10 @@ angular.module('upl-site').
         var failureGitHubResponseHandler = function (repoLink) {
           return function (response) {
             // TODO: test this failure case!
+            // TODO: this will happen if the rate limit is hit!
+            // XXX: maybe don't fetch the latest commit if the field is already valid...
+            // rate limit <-> reponse.status === 403
+            console.log('FAILURE!', response);
             ghRepos[repoLink].reject('Error loading GitHub information');
           };
         };

--- a/views/home.html
+++ b/views/home.html
@@ -43,20 +43,21 @@
         </ul>
     </section>
 
-    <section class="home-container projects-container" ng-if="projects.length">
+    <section class="home-container projects-container" ng-if="pairedProjects.length">
       <h2>Projects</h2>
-      Send us a <a href="https://github.com/UW-UPL/uw-upl.github.io">Pull Request on github</a> to add your projects here!
+      Send us a <a href="https://github.com/UW-UPL/uw-upl.github.io">Pull Request on GitHub</a> to add your projects here!
       <div class="project-table">
-        <div class="project-row" ng-repeat="pair in projects">
+        <div class="project-row" ng-repeat="pair in pairedProjects track by $index">
           <div class="project-box" ng-repeat="project in pair">
             <div class="project-inner-box">
               <h3 class="project-title"><a ng-href="/#/projects#proj-{{project.title}}">{{project.title}}</a></h3>
               <p>{{project.description}}</p>
-              <!--<pre>{{ project | json }}</pre>-->
-              <p ng-cloak>Last updated {{ project.latestCommitTimestamp | date }}</p>
+              <p ng-show='project.latestCommitTimestamp'>
+                Last updated {{ project.latestCommitTimestamp | date }}
+              </p>
             </div>
           </div>
         </div>
+      </div>
     </section>
-
 </div>

--- a/views/home.html
+++ b/views/home.html
@@ -52,6 +52,8 @@
             <div class="project-inner-box">
               <h3 class="project-title"><a ng-href="/#/projects#proj-{{project.title}}">{{project.title}}</a></h3>
               <p>{{project.description}}</p>
+              <!--<pre>{{ project | json }}</pre>-->
+              <p ng-cloak>Last updated {{ project.latestCommitTimestamp | date }}</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
This branch allows us to pull repo data from GitHub and sort projects accordingly (see #75)

Two things to mention:
- For projects that are not hosted on GitHub, their `latestCommitTimestamp` is set to `0`, which effectively sorts them by title alphabetically on the homepage. I included a note in the factory in case we want to allow users to supply the timestamp in the JSON.
- If we run into the issue of exhausting the rate limit on GitHub (a GET/403 error), the error is logged on the console. Since I accounted for this issue, even though the error shows up, nothing gets "messed up" -- sorting just defaults to ordering by title. This case should "never happen" as the rate limit is exceeded only when re-populating the factory (i.e. on page refresh) and only after a certain number of times ([60 per hour](https://developer.github.com/v3/#rate-limiting)).

Let me know if you have any requests/problems.