### PR TITLE
Sort upcoming events in chronological order

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -20,7 +20,7 @@ $(document).ready(function() {
     if (date.isBefore(now)) {
       previousEventsList.append(event);
     } else {
-      upcomingEventsList.append(event);
+      upcomingEventsList.prepend(event);
     }
   });
 


### PR DESCRIPTION
I believe that it is better for the sooner upcoming events to be listed first, instead of being buried by events happening later. Previous events should still be sorted most-recent first.