### PR TITLE
ensure footer © year is correct in perpetuity

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -14,7 +14,7 @@
     </div>
     <div class="uw-credit">
       <a href="http://www.wisc.edu/" title="University of Wisconsin-Madison"><img id="uw-logo" src="/images/uwlogo.png"></a>
-      <p>© 2018 The Board of Regents of the University of Wisconsin System<br>Feedback, questions, or issues: <a href="mailto:upl@cs.wisc.edu">upl@cs.wisc.edu</a></p>
+      <p>© {{ site.time | date: '%Y' }} The Board of Regents of the University of Wisconsin System<br>Feedback, questions, or issues: <a href="mailto:upl@cs.wisc.edu">upl@cs.wisc.edu</a></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
as in title. fixes the current "© 2018" issue