### PR TITLE
Add linked resources page

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -263,6 +263,13 @@ declare module 'astro:content' {
 } & { render(): Render[".md"] };
 };
 "resources": {
+".github/PULL_REQUEST_TEMPLATE/pull_request_template.md": {
+	id: ".github/PULL_REQUEST_TEMPLATE/pull_request_template.md";
+  slug: "github/pull_request_template/pull_request_template";
+  body: string;
+  collection: "resources";
+  data: any
+} & { render(): Render[".md"] };
 "README.md": {
 	id: "README.md";
   slug: "readme";

--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -263,13 +263,6 @@ declare module 'astro:content' {
 } & { render(): Render[".md"] };
 };
 "resources": {
-".github/PULL_REQUEST_TEMPLATE/pull_request_template.md": {
-	id: ".github/PULL_REQUEST_TEMPLATE/pull_request_template.md";
-  slug: "github/pull_request_template/pull_request_template";
-  body: string;
-  collection: "resources";
-  data: any
-} & { render(): Render[".md"] };
 "README.md": {
 	id: "README.md";
   slug: "readme";

--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -262,6 +262,15 @@ declare module 'astro:content' {
   data: InferEntrySchema<"events">
 } & { render(): Render[".md"] };
 };
+"resources": {
+"README.md": {
+	id: "README.md";
+  slug: "readme";
+  body: string;
+  collection: "resources";
+  data: any
+} & { render(): Render[".md"] };
+};
 
 	};
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v3
+        with:
+            submodules: recursive
       - name: Install, build, and upload your site
         uses: withastro/action@v0
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "resources"]
+[submodule "src/content/resources"]
 	path = src/content/resources
 	url = https://github.com/UW-UPL/resources.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "resources"]
-	path = resources
+	path = src/content/resources
 	url = https://github.com/UW-UPL/resources.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "resources"]
+	path = resources
+	url = https://github.com/UW-UPL/resources.git

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "uw-upl-website",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "uw-upl-website",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@astrojs/react": "^3.0.1",
         "@astrojs/sitemap": "^1.2.2",

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,6 +19,10 @@ const ROUTES: {
 		name: "Blog",
 	},
 	{
+		path: "/resources",
+		name: "Resources",
+	},
+	{
 		path: "/coords",
 		name: "Coords",
 	},

--- a/src/pages/resources.astro
+++ b/src/pages/resources.astro
@@ -1,0 +1,26 @@
+---
+import { getCollection } from "astro:content";
+import Layout from "../layouts/Layout.astro";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faChevronLeft, faCircleChevronLeft } from "@fortawesome/free-solid-svg-icons";
+
+const resources = await getCollection("resources");
+const readme_rendered = await resources.filter(d => d.id == "README.md")[0].render();
+---
+
+<Layout>
+	<div class="inline w-full overflow-hidden text-slate-800">
+		<a class="ml-8 flex flex-row basis-8 text-slate-500 text-sm space-x-1 active:underline hover:underline" href="/blog">
+			<div class="w-2.5 my-auto">
+				<FontAwesomeIcon icon={faChevronLeft}/>
+			</div>
+			<h1 class="font-sans font-semibold">Back</h1>
+		</a>
+
+		<div class="mx-auto w-3/4">
+            <div class="text-base/6 font-sans prose prose-lg prose-zinc">
+                <readme_rendered.Content>
+            </div>
+        </div>
+    </div>
+</Layout>


### PR DESCRIPTION
Add a "resources" page that is linked to the [upl resources repository](https://github.com/UW-UPL/resources) README (via a git submodule).

It's admittedly a little scuffed: the submodule is placed directly into src/content, and the astro file finds the README.md 
 by its name and renders it to the page.

I don't know if it's possible to cause the github action to re-run whenever the resources repo is updated; it would be cool if it did. Otherwise, the resources page will only update on manual re-runs and pushes to this repo.