### PR TITLE
add uw-coursemap to projects section

### DIFF
--- a/src/content/projects/uw-coursemap.json
+++ b/src/content/projects/uw-coursemap.json
@@ -1,0 +1,11 @@
+{
+    "title": "UW Course Map",
+    "source": "https://uwcourses.com",
+    "writeup": "https://docs.uwcourses.com",
+    "description": "Explore the courses offered by UW-Madison in a visual and interactive way.",
+    "image": "../../img/projects/uw-coursemap-logo.svg",
+    "authors": [
+        "James"
+    ]
+}
+

--- a/src/img/projects/uw-coursemap-logo.svg
+++ b/src/img/projects/uw-coursemap-logo.svg
@@ -1,0 +1,14 @@
+<svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+	<title>share-2 (1) (2)</title>
+	<style>
+		.s0 { fill: none;stroke: #c5050c;stroke-linecap: round;stroke-linejoin: round;stroke-width: 15 } 
+		.s1 { fill: #c5050c;stroke: #c5050c;stroke-linecap: round;stroke-linejoin: round;stroke-width: 14 } 
+	</style>
+	<g id="Layer 1">
+		<path fill-rule="evenodd" class="s0" d="m186.2 90.6c-15-8.6-20.3-27.8-11.8-43.8 8.6-14.9 28.9-20.3 43.8-11.7 15 9.6 20.3 28.8 11.8 43.7-8.6 16-28.9 21.4-43.8 11.8z"/>
+		<path fill-rule="evenodd" class="s1" d="m37.8 91.6c-14.9-8.5-20.3-28.8-11.7-43.7 8.5-15 28.8-20.3 43.7-11.8 15 8.6 20.3 28.9 11.8 43.8-8.6 14.9-28.8 20.3-43.8 11.7z"/>
+		<path fill-rule="evenodd" class="s0" d="m111.5 220.8c-15-9.6-20.3-28.8-11.8-43.8 8.6-16 28.8-21.3 43.8-11.7 14.9 8.5 20.3 27.8 11.7 43.8-8.5 14.9-28.8 20.2-43.7 11.7z"/>
+		<path fill-rule="evenodd" class="s0" d="m69.8 91.6l38 67.2"/>
+		<path fill-rule="evenodd" class="s0" d="m170.2 63.9h-84.4"/>
+	</g>
+</svg>


### PR DESCRIPTION
Adds [uwcourses.com](https://uwcourses.com) to be featured within the projects section.

I can also change the logo to a 600x600 jpg version, but the svg version is smaller than a compressed jpg.